### PR TITLE
Implement GPP criteria analyzer: suggest patches 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -45,6 +45,11 @@
       <artifactId>jackson-datatype-jsr310</artifactId>
       <version>2.17.1</version>
     </dependency>
+    <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-text</artifactId>
+      <version>1.13.0</version>
+    </dependency>
   </dependencies>
 
   <build>

--- a/src/main/java/it/polimi/gpplib/DefaultGppNoticeAnalyzer.java
+++ b/src/main/java/it/polimi/gpplib/DefaultGppNoticeAnalyzer.java
@@ -61,12 +61,12 @@ public class DefaultGppNoticeAnalyzer implements GppNoticeAnalyzer {
     }
 
     @Override
-    public List<SuggestedGppPatch> suggestPatches(List<SuggestedGppCriterion> suggestedCriteria) {
-        return domainKnowledge.suggestGppPatches(suggestedCriteria);
+    public List<SuggestedGppPatch> suggestPatches(Notice notice, List<SuggestedGppCriterion> suggestedCriteria) {
+        return domainKnowledge.suggestGppPatches(notice, suggestedCriteria);
     }
 
     @Override
-    public Notice applyPatches(List<SuggestedGppPatch> patches, Notice notice) {
+    public Notice applyPatches(Notice notice, List<SuggestedGppPatch> patches) {
         return null;
     }
 

--- a/src/main/java/it/polimi/gpplib/DefaultGppNoticeAnalyzer.java
+++ b/src/main/java/it/polimi/gpplib/DefaultGppNoticeAnalyzer.java
@@ -79,5 +79,8 @@ public class DefaultGppNoticeAnalyzer implements GppNoticeAnalyzer {
         GppAnalysisResult result = analyzer.analyzeNotice(notice);
         System.out.println("Notice: " + notice);
         System.out.println("Analysis Result: " + result);
+
+        List<SuggestedGppPatch> patches = analyzer.suggestPatches(notice, result.getSuggestedGppCriteria());
+        System.out.println("Suggested Patches: " + patches);
     }
 }

--- a/src/main/java/it/polimi/gpplib/DefaultGppNoticeAnalyzer.java
+++ b/src/main/java/it/polimi/gpplib/DefaultGppNoticeAnalyzer.java
@@ -37,6 +37,7 @@ public class DefaultGppNoticeAnalyzer implements GppNoticeAnalyzer {
 
     @Override
     public GppAnalysisResult analyzeNotice(Notice notice) {
+        // TODO: verify that the documents can't be duplicated
         java.util.Set<GppDocument> allRelevantDocuments = new java.util.HashSet<>(); // to avoid duplicates
         List<SuggestedGppCriterion> allSuggestedCriteria = new java.util.ArrayList<>();
 
@@ -73,7 +74,8 @@ public class DefaultGppNoticeAnalyzer implements GppNoticeAnalyzer {
     // temporary for testing purposes
     public static void main(String[] args) {
         DefaultGppNoticeAnalyzer analyzer = new DefaultGppNoticeAnalyzer();
-        String noticePath = "notices_furniture/00155175_2025.xml";
+        // String noticePath = "notices_furniture/00155175_2025.xml";
+        String noticePath = "notices_furniture/dummy.xml";
         String noticeXml = Utils.loadXmlString(noticePath);
         Notice notice = analyzer.loadNotice(noticeXml);
         GppAnalysisResult result = analyzer.analyzeNotice(notice);

--- a/src/main/java/it/polimi/gpplib/GppNoticeAnalyzer.java
+++ b/src/main/java/it/polimi/gpplib/GppNoticeAnalyzer.java
@@ -12,7 +12,7 @@ public interface GppNoticeAnalyzer {
 
     GppAnalysisResult analyzeNotice(Notice notice);
 
-    List<SuggestedGppPatch> suggestPatches(List<SuggestedGppCriterion> suggestedCriteria);
+    List<SuggestedGppPatch> suggestPatches(Notice notice, List<SuggestedGppCriterion> suggestedCriteria);
 
-    Notice applyPatches(List<SuggestedGppPatch> patches, Notice notice);
+    Notice applyPatches(Notice notice, List<SuggestedGppPatch> patches);
 }

--- a/src/main/java/it/polimi/gpplib/model/Constants.java
+++ b/src/main/java/it/polimi/gpplib/model/Constants.java
@@ -1,0 +1,13 @@
+package it.polimi.gpplib.model;
+
+public final class Constants {
+    public static final String AMBITION_LEVEL_CORE = "core";
+    public static final String AMBITION_LEVEL_COMPREHENSIVE = "comprehensive";
+    public static final String AMBITION_LEVEL_BOTH = "both";
+
+    public static final String PATCH_NAME_GPP_CRITERIA = "Green Public Procurement Criteria";
+    public static final String OP_CREATE = "create";
+
+    private Constants() {
+    } // Prevent instantiation
+}

--- a/src/main/java/it/polimi/gpplib/model/Constants.java
+++ b/src/main/java/it/polimi/gpplib/model/Constants.java
@@ -1,12 +1,50 @@
 package it.polimi.gpplib.model;
 
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
 public final class Constants {
     public static final String AMBITION_LEVEL_CORE = "core";
     public static final String AMBITION_LEVEL_COMPREHENSIVE = "comprehensive";
     public static final String AMBITION_LEVEL_BOTH = "both";
 
-    public static final String PATCH_NAME_GPP_CRITERIA = "Green Public Procurement Criteria";
     public static final String OP_CREATE = "create";
+    public static final String OP_UPDATE = "update";
+
+    public static final String PATCH_NAME_GPP_CRITERIA_SOURCE = "Green Public Procurement Criteria";
+    // TODO: rename this one to env impact in the sheet
+    public static final String PATCH_NAME_ENVIRONMENTAL_IMPACT = "Green Procurement";
+    // TODO: define better the expected description for this patch
+    public static final String PATCH_NAME_STRATEGIC_PROCUREMENT = "Strategic Procurement: Reduction of environmental impacts";
+
+    public static final String PATCH_DESCRIPTION_STRATEGIC_PROCUREMENT = "GPP criteria will be used to evaluate the proposals, accounting for environmental impact";
+
+    public static final String TAG_ARG0 = "arg0";
+    public static final String TAG_ARG1 = "arg1";
+    public static final String TAG_ARG2 = "arg2";
+    public static final String TAG_ARG3 = "arg3";
+    public static final String TAG_ARG4 = "arg4";
+    public static final String TAG_ARG5 = "arg5";
+    public static final String TAG_ARG6 = "arg6";
+
+    public static final String TAG_LANGUAGE = "language";
+    public static final String TAG_ENGLISH = "EN";
+
+    public static final Map<String, String> NAMESPACE_MAP;
+    static {
+        Map<String, String> map = new HashMap<>();
+        map.put("default", "urn:oasis:names:specification:ubl:schema:xsd:ContractNotice-2");
+        map.put("cac", "urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2");
+        map.put("cbc", "urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2");
+        map.put("efac", "http://data.europa.eu/p27/eforms-ubl-extension-aggregate-components/1");
+        map.put("efbc", "http://data.europa.eu/p27/eforms-ubl-extension-basic-components/1");
+        map.put("efext", "http://data.europa.eu/p27/eforms-ubl-extensions/1");
+        map.put("ext", "urn:oasis:names:specification:ubl:schema:xsd:CommonExtensionComponents-2");
+        map.put("xsd", "http://www.w3.org/2001/XMLSchema");
+        map.put("xsi", "http://www.w3.org/2001/XMLSchema-instance");
+        NAMESPACE_MAP = Collections.unmodifiableMap(map);
+    }
 
     private Constants() {
     } // Prevent instantiation

--- a/src/main/java/it/polimi/gpplib/model/Constants.java
+++ b/src/main/java/it/polimi/gpplib/model/Constants.java
@@ -12,11 +12,21 @@ public final class Constants {
     public static final String OP_CREATE = "create";
     public static final String OP_UPDATE = "update";
 
+    // notice these are lowercase
+    public static final String CRITERION_TYPE_AWARD_CRITERIA = "award criteria";
+    public static final String CRITERION_TYPE_SELECTION_CRITERIA = "selection criteria";
+    public static final String CRITERION_TYPE_CONTRACT_PERFORMANCE_CLAUSE = "contract performing clause";
+    public static final String CRITERION_TYPE_TECHNICAL_SPECIFICATION = "technical specification";
+
     public static final String PATCH_NAME_GPP_CRITERIA_SOURCE = "Green Public Procurement Criteria";
     // TODO: rename this one to env impact in the sheet
     public static final String PATCH_NAME_ENVIRONMENTAL_IMPACT = "Green Procurement";
     // TODO: define better the expected description for this patch
     public static final String PATCH_NAME_STRATEGIC_PROCUREMENT = "Strategic Procurement: Reduction of environmental impacts";
+
+    public static final String PATCH_NAME_AWARD_CRITERION = "Award Criterion";
+    public static final String PATCH_NAME_SELECTION_CRITERIA = "Selection Criteria";
+    public static final String PATCH_NAME_CONTRACT_PERFORMANCE_CLAUSE = "Contract Performance Clause";
 
     public static final String PATCH_DESCRIPTION_STRATEGIC_PROCUREMENT = "GPP criteria will be used to evaluate the proposals, accounting for environmental impact";
 
@@ -44,6 +54,17 @@ public final class Constants {
         map.put("xsd", "http://www.w3.org/2001/XMLSchema");
         map.put("xsi", "http://www.w3.org/2001/XMLSchema-instance");
         NAMESPACE_MAP = Collections.unmodifiableMap(map);
+    }
+
+    public static final Map<String, String> CRITERION_TYPE_TO_PATCH_NAME;
+    static {
+        Map<String, String> map = new HashMap<>();
+        map.put(CRITERION_TYPE_AWARD_CRITERIA, PATCH_NAME_AWARD_CRITERION);
+        map.put(CRITERION_TYPE_SELECTION_CRITERIA, PATCH_NAME_SELECTION_CRITERIA);
+        map.put(CRITERION_TYPE_CONTRACT_PERFORMANCE_CLAUSE, PATCH_NAME_CONTRACT_PERFORMANCE_CLAUSE);
+        // TODO: revise the logic of adding technical specifications as award criteria
+        map.put(CRITERION_TYPE_TECHNICAL_SPECIFICATION, PATCH_NAME_AWARD_CRITERION);
+        CRITERION_TYPE_TO_PATCH_NAME = Collections.unmodifiableMap(map);
     }
 
     private Constants() {

--- a/src/main/java/it/polimi/gpplib/model/Notice.java
+++ b/src/main/java/it/polimi/gpplib/model/Notice.java
@@ -173,7 +173,7 @@ public class Notice {
     }
 
     /**
-     * Helper: Finds the ProcurementProjectLot node for a given lot ID.
+     * Finds the ProcurementProjectLot node for a given lot ID.
      * This version finds all lots, checks their ID child, and returns the matching
      * lot node.
      */

--- a/src/main/java/it/polimi/gpplib/model/Notice.java
+++ b/src/main/java/it/polimi/gpplib/model/Notice.java
@@ -49,6 +49,7 @@ public class Notice {
     }
 
     // TODO: get this from the SDK or something
+    // TODO: you could even get it from the constants for now
     private static final NamespaceContext namespaceCtx = new NamespaceContext() {
         @Override
         public String getNamespaceURI(String prefix) {
@@ -193,6 +194,22 @@ public class Notice {
             System.err.println("Failed to find lot node for lotId " + lotId + ": " + e.getMessage());
         }
         return null;
+    }
+
+    public boolean doesPathExistInLot(String lotId, String path) {
+        Node lotNode = getLotNode(lotId);
+        if (lotNode == null) {
+            return false;
+        }
+        try {
+            XPath xpath = xpathFactory.newXPath();
+            xpath.setNamespaceContext(namespaceCtx);
+            Node node = (Node) xpath.evaluate(path, lotNode, XPathConstants.NODE);
+            return node != null;
+        } catch (Exception e) {
+            System.err.println("Failed to check path existence in lot " + lotId + ": " + e.getMessage());
+            return false;
+        }
     }
 
     /**

--- a/src/main/java/it/polimi/gpplib/model/SuggestedGppPatch.java
+++ b/src/main/java/it/polimi/gpplib/model/SuggestedGppPatch.java
@@ -110,4 +110,43 @@ public class SuggestedGppPatch {
                 ", lotId='" + lotId + '\'' +
                 '}';
     }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o)
+            return true;
+        if (o == null || getClass() != o.getClass())
+            return false;
+
+        SuggestedGppPatch that = (SuggestedGppPatch) o;
+
+        if (name != null ? !name.equals(that.name) : that.name != null)
+            return false;
+        if (btIds != null ? !btIds.equals(that.btIds) : that.btIds != null)
+            return false;
+        if (dependsOn != null ? !dependsOn.equals(that.dependsOn) : that.dependsOn != null)
+            return false;
+        if (path != null ? !path.equals(that.path) : that.path != null)
+            return false;
+        if (value != null ? !value.equals(that.value) : that.value != null)
+            return false;
+        if (op != null ? !op.equals(that.op) : that.op != null)
+            return false;
+        if (description != null ? !description.equals(that.description) : that.description != null)
+            return false;
+        return lotId != null ? lotId.equals(that.lotId) : that.lotId == null;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = name != null ? name.hashCode() : 0;
+        result = 31 * result + (btIds != null ? btIds.hashCode() : 0);
+        result = 31 * result + (dependsOn != null ? dependsOn.hashCode() : 0);
+        result = 31 * result + (path != null ? path.hashCode() : 0);
+        result = 31 * result + (value != null ? value.hashCode() : 0);
+        result = 31 * result + (op != null ? op.hashCode() : 0);
+        result = 31 * result + (description != null ? description.hashCode() : 0);
+        result = 31 * result + (lotId != null ? lotId.hashCode() : 0);
+        return result;
+    }
 }

--- a/src/main/java/it/polimi/gpplib/model/SuggestedGppPatch.java
+++ b/src/main/java/it/polimi/gpplib/model/SuggestedGppPatch.java
@@ -16,12 +16,13 @@ public class SuggestedGppPatch {
     private String value;
     private String op;
     private String description;
+    private String lotId;
 
     public SuggestedGppPatch() {
     }
 
     public SuggestedGppPatch(String name, List<String> btIds, String dependsOn, String path, String value,
-            String op, String description) {
+            String op, String description, String lotId) {
         this.name = name;
         this.btIds = btIds;
         this.dependsOn = dependsOn;
@@ -29,6 +30,7 @@ public class SuggestedGppPatch {
         this.value = value;
         this.op = op;
         this.description = description;
+        this.lotId = lotId;
     }
 
     public String getName() {
@@ -87,6 +89,14 @@ public class SuggestedGppPatch {
         this.description = description;
     }
 
+    public String getLotId() {
+        return lotId;
+    }
+
+    public void setLotId(String lotId) {
+        this.lotId = lotId;
+    }
+
     @Override
     public String toString() {
         return "SuggestedGppPatch{" +
@@ -97,6 +107,7 @@ public class SuggestedGppPatch {
                 ", value='" + value + '\'' +
                 ", op='" + op + '\'' +
                 ", description='" + description + '\'' +
+                ", lotId='" + lotId + '\'' +
                 '}';
     }
 }

--- a/src/main/java/it/polimi/gpplib/utils/GppDomainKnowledgeService.java
+++ b/src/main/java/it/polimi/gpplib/utils/GppDomainKnowledgeService.java
@@ -3,6 +3,7 @@ package it.polimi.gpplib.utils;
 import it.polimi.gpplib.model.GppDocument;
 import it.polimi.gpplib.model.GppCriterion;
 import it.polimi.gpplib.model.GppPatch;
+import it.polimi.gpplib.model.Notice;
 import it.polimi.gpplib.model.SuggestedGppCriterion;
 import it.polimi.gpplib.model.SuggestedGppPatch;
 
@@ -78,15 +79,15 @@ public class GppDomainKnowledgeService {
         return suggested;
     }
 
-    public List<SuggestedGppPatch> suggestGppPatches(List<SuggestedGppCriterion> suggestedCriteria) {
-
-        // private final GppPatchesLoader patchesLoader = new GppPatchesLoader();
-
-        // remember to include the global patches (e.g. document, changes section)
-        // will probs need to convert he SuggestedGppCriterion to GppCriterion
+    public List<SuggestedGppPatch> suggestGppPatches(Notice notice, List<SuggestedGppCriterion> suggestedCriteria) {
 
         // we first need to convert the suggested criteria to GppCriteria to get the
         // internal details
+
+        // then
+
+        // remember to include the global patches (e.g. document, changes section)
+        // will probs need to convert he SuggestedGppCriterion to GppCriterion
 
         // ??++ AQUI
         return List.of(); // Placeholder return

--- a/src/main/java/it/polimi/gpplib/utils/GppDomainKnowledgeService.java
+++ b/src/main/java/it/polimi/gpplib/utils/GppDomainKnowledgeService.java
@@ -8,12 +8,17 @@ import it.polimi.gpplib.model.SuggestedGppCriterion;
 import it.polimi.gpplib.model.SuggestedGppPatch;
 
 import java.util.List;
+import java.util.Map;
+
+import java.util.HashMap;
 
 public class GppDomainKnowledgeService {
 
     private List<GppDocument> gppDocs = new java.util.ArrayList<>();
     private List<GppCriterion> gppCriteria = new java.util.ArrayList<>();
     private List<GppPatch> gppPatches = new java.util.ArrayList<>();
+
+    private final GppPatchSuggester patchSuggester;
 
     public GppDomainKnowledgeService() {
         try {
@@ -29,6 +34,8 @@ public class GppDomainKnowledgeService {
             System.err.println("Failed to load GPP domain knowledge: " + e.getMessage());
             e.printStackTrace();
         }
+
+        patchSuggester = new GppPatchSuggester(gppCriteria, gppPatches);
     }
 
     // TODO: eventually, the relevant documents should only come from the relevant
@@ -61,9 +68,6 @@ public class GppDomainKnowledgeService {
             List<String> lotCpvs) {
         List<SuggestedGppCriterion> suggested = new java.util.ArrayList<>();
         for (GppCriterion criterion : criteria) {
-            // compute matching CPVs between the lot and the criterion
-            List<String> matchingCpvs = Utils.matchingCpvs(lotCpvs, criterion.getRelevantCpvCodes());
-
             SuggestedGppCriterion s = new SuggestedGppCriterion(
                     criterion.getGppDocument(),
                     criterion.getCategory(),
@@ -72,7 +76,7 @@ public class GppDomainKnowledgeService {
                     criterion.getId(),
                     criterion.getName(),
                     criterion.getRelevantCpvCodes(),
-                    matchingCpvs,
+                    Utils.matchingCpvs(lotCpvs, criterion.getRelevantCpvCodes()),
                     lotId);
             suggested.add(s);
         }
@@ -80,34 +84,7 @@ public class GppDomainKnowledgeService {
     }
 
     public List<SuggestedGppPatch> suggestGppPatches(Notice notice, List<SuggestedGppCriterion> suggestedCriteria) {
-
-        // we first need to convert the suggested criteria to GppCriteria to get the
-        // internal details
-
-        // then
-
-        // remember to include the global patches (e.g. document, changes section)
-        // will probs need to convert he SuggestedGppCriterion to GppCriterion
-
-        // ??++ AQUI
-        return List.of(); // Placeholder return
+        List<SuggestedGppPatch> suggestedPatches = patchSuggester.suggestGppPatches(notice, suggestedCriteria);
+        return suggestedPatches;
     }
-
-    private List<GppCriterion> convertToGppCriteria(List<SuggestedGppCriterion> suggestedCriteria) {
-        // List<GppCriterion> criteria = new java.util.ArrayList<>();
-        // for (SuggestedGppCriterion s : suggestedCriteria) {
-        // GppCriterion c = new GppCriterion(
-        // s.getGppDocument(),
-        // s.getCategory(),
-        // s.getCriterionType(),
-        // s.getAmbitionLevel(),
-        // s.getId(),
-        // s.getName(),
-        // s.getRelevantCpvCodes());
-        // criteria.add(c);
-        // }
-        // return criteria;
-        return List.of(); // Placeholder return
-    }
-
 }

--- a/src/main/java/it/polimi/gpplib/utils/GppDomainKnowledgeService.java
+++ b/src/main/java/it/polimi/gpplib/utils/GppDomainKnowledgeService.java
@@ -84,7 +84,6 @@ public class GppDomainKnowledgeService {
     }
 
     public List<SuggestedGppPatch> suggestGppPatches(Notice notice, List<SuggestedGppCriterion> suggestedCriteria) {
-        List<SuggestedGppPatch> suggestedPatches = patchSuggester.suggestGppPatches(notice, suggestedCriteria);
-        return suggestedPatches;
+        return patchSuggester.suggestGppPatches(notice, suggestedCriteria);
     }
 }

--- a/src/main/java/it/polimi/gpplib/utils/GppDomainKnowledgeService.java
+++ b/src/main/java/it/polimi/gpplib/utils/GppDomainKnowledgeService.java
@@ -9,46 +9,46 @@ import it.polimi.gpplib.model.SuggestedGppPatch;
 import java.util.List;
 
 public class GppDomainKnowledgeService {
-    private final GppDocumentsLoader docsLoader = new GppDocumentsLoader();
-    private final GppCriteriaLoader criteriaLoader = new GppCriteriaLoader();
-    private final GppPatchesLoader patchesLoader = new GppPatchesLoader();
+
+    private List<GppDocument> gppDocs = new java.util.ArrayList<>();
+    private List<GppCriterion> gppCriteria = new java.util.ArrayList<>();
+    private List<GppPatch> gppPatches = new java.util.ArrayList<>();
 
     public GppDomainKnowledgeService() {
+        try {
+            GppDocumentsLoader docsLoader = new GppDocumentsLoader();
+            gppDocs = docsLoader.loadGppDocuments();
+
+            GppCriteriaLoader criteriaLoader = new GppCriteriaLoader();
+            gppCriteria = criteriaLoader.loadGppCriteria();
+
+            GppPatchesLoader patchesLoader = new GppPatchesLoader();
+            gppPatches = patchesLoader.loadGppPatches();
+        } catch (Exception e) {
+            System.err.println("Failed to load GPP domain knowledge: " + e.getMessage());
+            e.printStackTrace();
+        }
     }
 
     // TODO: eventually, the relevant documents should only come from the relevant
     // GPP criteria (looking at the document names)
     public List<GppDocument> getRelevantGppDocuments(List<String> cpvs) {
         List<GppDocument> relevantGppDocs = new java.util.ArrayList<>();
-        try {
-            List<GppDocument> gppDocs = docsLoader.loadGppDocuments();
-            for (GppDocument doc : gppDocs) {
-                if (doc.isApplicable(cpvs)) {
-                    relevantGppDocs.add(doc);
-                }
+        for (GppDocument doc : gppDocs) {
+            if (doc.isApplicable(cpvs)) {
+                relevantGppDocs.add(doc);
             }
-        } catch (Exception e) {
-            System.err.println("Failed to load GPP documents: " + e.getMessage());
-            e.printStackTrace();
         }
-
         return relevantGppDocs;
     }
 
     public List<GppCriterion> getRelevantGppCriteria(List<String> cpvs, String ambitionLevel) {
         List<GppCriterion> relevantGppCriteria = new java.util.ArrayList<>();
-        try {
-            List<GppCriterion> gppCriteria = criteriaLoader.loadGppCriteria();
-            for (GppCriterion criterion : gppCriteria) {
-                if (criterion.isApplicable(cpvs, ambitionLevel)) {
-                    relevantGppCriteria.add(criterion);
-                }
+        for (GppCriterion criterion : gppCriteria) {
+            if (criterion.isApplicable(cpvs, ambitionLevel)) {
+                relevantGppCriteria.add(criterion);
             }
-        } catch (Exception e) {
-            System.err.println("Failed to load GPP criteria: " + e.getMessage());
-            e.printStackTrace();
         }
-
         return relevantGppCriteria;
     }
 
@@ -78,11 +78,34 @@ public class GppDomainKnowledgeService {
         return suggested;
     }
 
-    public List<SuggestedGppPatch> suggestGppPatches(List<SuggestedGppCriterion> criteria) {
+    public List<SuggestedGppPatch> suggestGppPatches(List<SuggestedGppCriterion> suggestedCriteria) {
+
+        // private final GppPatchesLoader patchesLoader = new GppPatchesLoader();
+
         // remember to include the global patches (e.g. document, changes section)
         // will probs need to convert he SuggestedGppCriterion to GppCriterion
 
+        // we first need to convert the suggested criteria to GppCriteria to get the
+        // internal details
+
         // ??++ AQUI
+        return List.of(); // Placeholder return
+    }
+
+    private List<GppCriterion> convertToGppCriteria(List<SuggestedGppCriterion> suggestedCriteria) {
+        // List<GppCriterion> criteria = new java.util.ArrayList<>();
+        // for (SuggestedGppCriterion s : suggestedCriteria) {
+        // GppCriterion c = new GppCriterion(
+        // s.getGppDocument(),
+        // s.getCategory(),
+        // s.getCriterionType(),
+        // s.getAmbitionLevel(),
+        // s.getId(),
+        // s.getName(),
+        // s.getRelevantCpvCodes());
+        // criteria.add(c);
+        // }
+        // return criteria;
         return List.of(); // Placeholder return
     }
 

--- a/src/main/java/it/polimi/gpplib/utils/GppDomainKnowledgeService.java
+++ b/src/main/java/it/polimi/gpplib/utils/GppDomainKnowledgeService.java
@@ -81,6 +81,8 @@ public class GppDomainKnowledgeService {
     public List<SuggestedGppPatch> suggestGppPatches(List<SuggestedGppCriterion> criteria) {
         // remember to include the global patches (e.g. document, changes section)
         // will probs need to convert he SuggestedGppCriterion to GppCriterion
+
+        // ??++ AQUI
         return List.of(); // Placeholder return
     }
 

--- a/src/main/java/it/polimi/gpplib/utils/GppPatchSuggester.java
+++ b/src/main/java/it/polimi/gpplib/utils/GppPatchSuggester.java
@@ -280,9 +280,9 @@ public class GppPatchSuggester {
     private List<String> getEnvironmentalImpacts(List<GppCriterion> criteria) {
         List<String> environmentalImpacts = new java.util.ArrayList<>();
         for (GppCriterion criterion : criteria) {
-            String environmentaImpact = criterion.getEnvironmentalImpactType();
-            if (environmentaImpact != null && !environmentalImpacts.contains(environmentaImpact)) {
-                environmentalImpacts.add(environmentaImpact);
+            String environmentalImpact = criterion.getEnvironmentalImpactType();
+            if (environmentalImpact != null && !environmentalImpacts.contains(environmentalImpact)) {
+                environmentalImpacts.add(environmentalImpact);
             }
         }
         return environmentalImpacts;

--- a/src/main/java/it/polimi/gpplib/utils/GppPatchSuggester.java
+++ b/src/main/java/it/polimi/gpplib/utils/GppPatchSuggester.java
@@ -49,6 +49,7 @@ public class GppPatchSuggester {
 
         List<SuggestedGppPatch> suggestedPatches = new java.util.ArrayList<>();
 
+        // GPP CRITERIA PATCHES
         GppPatch gppCriteriaPatch = findGppPatchByName(Constants.PATCH_NAME_GPP_CRITERIA);
         List<String> gppSources = getGppSources(lotCriteria);
         for (String source : gppSources) {
@@ -63,8 +64,8 @@ public class GppPatchSuggester {
                     parsedValue,
                     Constants.OP_CREATE,
                     // TODO: should add a description to the patches sheet
-                    "Dummy Description for Green Public Procurement Criteria" // Placeholder description
-            );
+                    "Dummy Description for Green Public Procurement Criteria", // Placeholder description
+                    lotId);
             suggestedPatches.add(gppSourcePatch);
         }
 

--- a/src/main/java/it/polimi/gpplib/utils/GppPatchSuggester.java
+++ b/src/main/java/it/polimi/gpplib/utils/GppPatchSuggester.java
@@ -1,0 +1,136 @@
+package it.polimi.gpplib.utils;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import it.polimi.gpplib.model.Constants;
+import it.polimi.gpplib.model.GppCriterion;
+import it.polimi.gpplib.model.GppPatch;
+import it.polimi.gpplib.model.Notice;
+import it.polimi.gpplib.model.SuggestedGppCriterion;
+import it.polimi.gpplib.model.SuggestedGppPatch;
+
+public class GppPatchSuggester {
+
+    private List<GppCriterion> gppCriteria = new java.util.ArrayList<>();
+    private List<GppPatch> gppPatches = new java.util.ArrayList<>();
+
+    public GppPatchSuggester(List<GppCriterion> gppCriteria, List<GppPatch> gppPatches) {
+        this.gppCriteria = gppCriteria;
+        this.gppPatches = gppPatches;
+    }
+
+    /**
+     * Suggests GPP patches based on the provided notice and suggested criteria.
+     * 
+     * @param notice            the notice to analyze
+     * @param suggestedCriteria the list of suggested GPP criteria
+     * @return a list of suggested GPP patches
+     */
+    public List<SuggestedGppPatch> suggestGppPatches(Notice notice, List<SuggestedGppCriterion> suggestedCriteria) {
+        Map<String, List<GppCriterion>> criteriaPerLot = getCriteriaPerLot(suggestedCriteria);
+
+        List<SuggestedGppPatch> allPatches = new java.util.ArrayList<>();
+        for (String lotId : criteriaPerLot.keySet()) {
+            List<GppCriterion> lotCriteria = criteriaPerLot.get(lotId);
+            List<SuggestedGppPatch> lotPatches = suggestGppPatchesForLot(notice, lotId, lotCriteria);
+            allPatches.addAll(lotPatches);
+        }
+
+        return allPatches;
+    }
+
+    private List<SuggestedGppPatch> suggestGppPatchesForLot(Notice notice, String lotId,
+            List<GppCriterion> lotCriteria) {
+
+        // TODO: eventually, should look at the notice to avoid or verify suggestions
+        // For now, we just return everything
+
+        List<SuggestedGppPatch> suggestedPatches = new java.util.ArrayList<>();
+
+        GppPatch gppCriteriaPatch = findGppPatchByName(Constants.PATCH_NAME_GPP_CRITERIA);
+        List<String> gppSources = getGppSources(lotCriteria);
+        for (String source : gppSources) {
+            String parsedValue = "dummy-value" + source;
+            // ??++ AQUI: parse the value from the gppCriteriaPatch
+            // Create a patch for each GPP source
+            SuggestedGppPatch gppSourcePatch = new SuggestedGppPatch(
+                    Constants.PATCH_NAME_GPP_CRITERIA,
+                    gppCriteriaPatch.getBtIds(),
+                    gppCriteriaPatch.getDependsOn(),
+                    gppCriteriaPatch.getPathInLot(),
+                    parsedValue,
+                    Constants.OP_CREATE,
+                    // TODO: should add a description to the patches sheet
+                    "Dummy Description for Green Public Procurement Criteria" // Placeholder description
+            );
+            suggestedPatches.add(gppSourcePatch);
+        }
+
+        return suggestedPatches;
+    }
+
+    private GppPatch findGppPatchByName(String name) {
+        for (GppPatch patch : gppPatches) {
+            if (patch.getName().equalsIgnoreCase(name)) {
+                return patch;
+            }
+        }
+        return null; // Not found
+    }
+
+    private List<String> getGppSources(List<GppCriterion> criteria) {
+        List<String> sources = new java.util.ArrayList<>();
+        for (GppCriterion criterion : criteria) {
+            String source = criterion.getGppSource();
+            if (source != null && !sources.contains(source)) {
+                sources.add(source);
+            }
+        }
+        return sources;
+    }
+
+    /**
+     * Returns the corresponding GppCriterion that contains all the internal details
+     * for a given SuggestedGppCriterion, or null if not found.
+     *
+     * @param suggestedCriterion the suggested criterion to match
+     * @return the matching GppCriterion, or null if not found
+     */
+    private GppCriterion convertToGppCriterion(SuggestedGppCriterion suggestedCriterion) {
+        for (GppCriterion criterion : gppCriteria) {
+            boolean idMatch = suggestedCriterion.getId() != null
+                    && suggestedCriterion.getId().equalsIgnoreCase(criterion.getId());
+            boolean ambitionMatch = suggestedCriterion.getAmbitionLevel() != null
+                    && suggestedCriterion.getAmbitionLevel().equalsIgnoreCase(criterion.getAmbitionLevel());
+            boolean docMatch = suggestedCriterion.getGppDocument() != null
+                    && suggestedCriterion.getGppDocument().equalsIgnoreCase(criterion.getGppDocument());
+            if (idMatch && ambitionMatch && docMatch) {
+                return criterion;
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Groups GppCriterion objects by lotId, based on the provided list of
+     * SuggestedGppCriterion.
+     * The returned map has lotId as key and the list of matching GppCriterion as
+     * value.
+     */
+    private Map<String, List<GppCriterion>> getCriteriaPerLot(List<SuggestedGppCriterion> suggestedCriteria) {
+        Map<String, List<GppCriterion>> criteriaPerLot = new HashMap<>();
+        for (SuggestedGppCriterion suggested : suggestedCriteria) {
+            String lotId = suggested.getLotId();
+            GppCriterion gppCriterion = convertToGppCriterion(suggested);
+            if (gppCriterion == null) {
+                System.err.println("No matching GppCriterion found for suggested criterion: " + suggested);
+                continue;
+            }
+            criteriaPerLot.computeIfAbsent(lotId, k -> new java.util.ArrayList<>()).add(gppCriterion);
+        }
+        return criteriaPerLot;
+    }
+
+}

--- a/src/main/resources/notices_furniture/dummy.xml
+++ b/src/main/resources/notices_furniture/dummy.xml
@@ -1,0 +1,558 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<ContractNotice xmlns="urn:oasis:names:specification:ubl:schema:xsd:ContractNotice-2"
+	xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2"
+	xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2"
+	xmlns:ccts-cct="urn:un:unece:uncefact:data:specification:CoreComponentTypeSchemaModule:2"
+	xmlns:efac="http://data.europa.eu/p27/eforms-ubl-extension-aggregate-components/1"
+	xmlns:efbc="http://data.europa.eu/p27/eforms-ubl-extension-basic-components/1"
+	xmlns:efext="http://data.europa.eu/p27/eforms-ubl-extensions/1"
+	xmlns:ext="urn:oasis:names:specification:ubl:schema:xsd:CommonExtensionComponents-2"
+	xmlns:qdt="urn:oasis:names:specification:ubl:schema:xsd:QualifiedDataTypes-2"
+	xmlns:udt="urn:oasis:names:specification:bdndr:schema:xsd:UnqualifiedDataTypes-1"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+	<ext:UBLExtensions>
+		<ext:UBLExtension>
+			<ext:ExtensionContent>
+				<efext:EformsExtension>
+					<efac:Changes>
+						<efbc:ChangedNoticeIdentifier>860c0486-cc1e-4c38-9bb9-5ae721443188-01</efbc:ChangedNoticeIdentifier>
+						<efac:Change>
+							<efbc:ChangeDescription languageID="DEU">Die Einreichungsfrist wird auf den 28.03.2025 10:00 Uhr verschoben.</efbc:ChangeDescription>
+							<efbc:ProcurementDocumentsChangeIndicator>false</efbc:ProcurementDocumentsChangeIndicator>
+							<efac:ChangedSection>
+								<efbc:ChangedSectionIdentifier>PROCEDURE</efbc:ChangedSectionIdentifier>
+							</efac:ChangedSection>
+						</efac:Change>
+						<efac:ChangeReason>
+							<cbc:ReasonCode listName="change-corrig-justification">update-add</cbc:ReasonCode>
+							<efbc:ReasonDescription languageID="DEU">Die Einreichungsfrist wird auf den 28.03.2025 10:00 Uhr verschoben.</efbc:ReasonDescription>
+						</efac:ChangeReason>
+					</efac:Changes>
+					<efac:NoticeSubType>
+						<cbc:SubTypeCode listName="notice-subtype">16</cbc:SubTypeCode>
+					</efac:NoticeSubType>
+					<efac:Organizations>
+						<efac:Organization>
+							<efac:Company>
+								<cac:PartyIdentification>
+									<cbc:ID>ORG-0001</cbc:ID>
+								</cac:PartyIdentification>
+								<cac:PartyName>
+									<cbc:Name languageID="DEU">Stadt Recklinghausen</cbc:Name>
+								</cac:PartyName>
+								<cac:PostalAddress>
+									<cbc:StreetName>Rathausplatz 3/4</cbc:StreetName>
+									<cbc:CityName>Recklinghausen</cbc:CityName>
+									<cbc:PostalZone>45657</cbc:PostalZone>
+									<cbc:CountrySubentityCode listName="nuts-lvl3">DEA36</cbc:CountrySubentityCode>
+									<cac:Country>
+										<cbc:IdentificationCode>DEU</cbc:IdentificationCode>
+									</cac:Country>
+								</cac:PostalAddress>
+								<cac:PartyLegalEntity>
+									<cbc:CompanyID>055620032032-31003-86</cbc:CompanyID>
+								</cac:PartyLegalEntity>
+								<cac:Contact>
+									<cbc:Name>Büro des Bürgermeisters - Vergabe -</cbc:Name>
+									<cbc:Telephone>+49 2361500</cbc:Telephone>
+									<cbc:Telefax>+49 2361502325</cbc:Telefax>
+									<cbc:ElectronicMail>vergabe@recklinghausen.de</cbc:ElectronicMail>
+								</cac:Contact>
+							</efac:Company>
+						</efac:Organization>
+						<efac:Organization>
+							<efac:Company>
+								<cac:PartyIdentification>
+									<cbc:ID>ORG-0002</cbc:ID>
+								</cac:PartyIdentification>
+								<cac:PartyName>
+									<cbc:Name languageID="DEU">Vergabekammer der Bezirksregierung Münster</cbc:Name>
+								</cac:PartyName>
+								<cac:PostalAddress>
+									<cbc:StreetName>Albrecht-Thaer-Str. 9</cbc:StreetName>
+									<cbc:CityName>Münster</cbc:CityName>
+									<cbc:PostalZone>48147</cbc:PostalZone>
+									<cbc:CountrySubentityCode listName="nuts-lvl3">DEA33</cbc:CountrySubentityCode>
+									<cac:Country>
+										<cbc:IdentificationCode>DEU</cbc:IdentificationCode>
+									</cac:Country>
+								</cac:PostalAddress>
+								<cac:PartyLegalEntity>
+									<cbc:CompanyID>DE164242157</cbc:CompanyID>
+								</cac:PartyLegalEntity>
+								<cac:Contact>
+									<cbc:Telephone>+49 2514111691</cbc:Telephone>
+									<cbc:Telefax>+49 2514112165</cbc:Telefax>
+									<cbc:ElectronicMail>vergabekammer@bezreg-muenster.nrw.de</cbc:ElectronicMail>
+								</cac:Contact>
+							</efac:Company>
+						</efac:Organization>
+						<efac:Organization>
+							<efac:Company>
+								<cac:PartyIdentification>
+									<cbc:ID schemeName="organization">ORG-0003</cbc:ID>
+								</cac:PartyIdentification>
+								<cac:PartyName>
+									<cbc:Name languageID="DEU">Datenservice Öffentlicher Einkauf (in Verantwortung des Beschaffungsamts des BMI)</cbc:Name>
+								</cac:PartyName>
+								<cac:PostalAddress>
+									<cbc:CityName>Bonn</cbc:CityName>
+									<cbc:PostalZone>53119</cbc:PostalZone>
+									<cbc:CountrySubentityCode listName="nuts">DEA22</cbc:CountrySubentityCode>
+									<cac:Country>
+										<cbc:IdentificationCode listName="country">DEU</cbc:IdentificationCode>
+									</cac:Country>
+								</cac:PostalAddress>
+								<cac:PartyLegalEntity>
+									<cbc:CompanyID schemeID="002">0204:994-DOEVD-83</cbc:CompanyID>
+								</cac:PartyLegalEntity>
+								<cac:Contact>
+									<cbc:Telephone>+49228996100</cbc:Telephone>
+									<cbc:ElectronicMail>noreply.esender_hub@bescha.bund.de</cbc:ElectronicMail>
+								</cac:Contact>
+							</efac:Company>
+						</efac:Organization>
+					</efac:Organizations>
+					<efac:Publication>
+						<efbc:NoticePublicationID schemeName="ojs-notice-id">00155175-2025</efbc:NoticePublicationID>
+						<efbc:GazetteID schemeName="ojs-id">48/2025</efbc:GazetteID>
+						<efbc:PublicationDate>2025-03-10+01:00</efbc:PublicationDate>
+					</efac:Publication>
+				</efext:EformsExtension>
+			</ext:ExtensionContent>
+		</ext:UBLExtension>
+	</ext:UBLExtensions>
+	<cbc:UBLVersionID>2.3</cbc:UBLVersionID>
+	<cbc:CustomizationID>eforms-sdk-1.10</cbc:CustomizationID>
+	<cbc:ID schemeName="notice-id">888aceb2-1f2b-4915-924f-844cad571513</cbc:ID>
+	<cbc:ContractFolderID>037ef1bf-d8c4-42f7-be98-55ca2e94b529</cbc:ContractFolderID>
+	<cbc:IssueDate>2025-03-07+01:00</cbc:IssueDate>
+	<cbc:IssueTime>08:47:05+01:00</cbc:IssueTime>
+	<cbc:VersionID>01</cbc:VersionID>
+	<cbc:RequestedPublicationDate>2025-03-07+01:00</cbc:RequestedPublicationDate>
+	<cbc:RegulatoryDomain>32014L0024</cbc:RegulatoryDomain>
+	<cbc:NoticeTypeCode listName="competition">cn-standard</cbc:NoticeTypeCode>
+	<cbc:NoticeLanguageCode listID="eu-official-language">DEU</cbc:NoticeLanguageCode>
+	<cac:ContractingParty>
+		<cac:ContractingPartyType>
+			<cbc:PartyTypeCode listName="buyer-legal-type">la</cbc:PartyTypeCode>
+		</cac:ContractingPartyType>
+		<cac:ContractingActivity>
+			<cbc:ActivityTypeCode listName="authority-activity">gen-pub</cbc:ActivityTypeCode>
+		</cac:ContractingActivity>
+		<cac:Party>
+			<cac:PartyIdentification>
+				<cbc:ID>ORG-0001</cbc:ID>
+			</cac:PartyIdentification>
+			<cac:ServiceProviderParty>
+				<cbc:ServiceTypeCode listName="organisation-role">ted-esen</cbc:ServiceTypeCode>
+				<cac:Party>
+					<cac:PartyIdentification>
+						<cbc:ID schemeName="organization">ORG-0003</cbc:ID>
+					</cac:PartyIdentification>
+				</cac:Party>
+			</cac:ServiceProviderParty>
+		</cac:Party>
+	</cac:ContractingParty>
+	<cac:TenderingTerms>
+		<cbc:FundingProgramCode listName="eu-funded">no-eu-funds</cbc:FundingProgramCode>
+		<cac:RequiredFinancialGuarantee>
+			<cbc:GuaranteeTypeCode listName="tender-guarantee-required">false</cbc:GuaranteeTypeCode>
+		</cac:RequiredFinancialGuarantee>
+		<cac:ProcurementLegislationDocumentReference>
+			<cbc:ID>vgv</cbc:ID>
+		</cac:ProcurementLegislationDocumentReference>
+		<cac:CallForTendersDocumentReference>
+			<ext:UBLExtensions>
+				<ext:UBLExtension>
+					<ext:ExtensionContent>
+						<efext:EformsExtension>
+							<efac:OfficialLanguages>
+								<cac:Language>
+									<cbc:ID>DEU</cbc:ID>
+								</cac:Language>
+							</efac:OfficialLanguages>
+						</efext:EformsExtension>
+					</ext:ExtensionContent>
+				</ext:UBLExtension>
+			</ext:UBLExtensions>
+			<cbc:ID>SomeTenderDocID1</cbc:ID>
+			<cbc:DocumentType>non-restricted-document</cbc:DocumentType>
+		</cac:CallForTendersDocumentReference>
+		<cac:TendererQualificationRequest>
+			<cac:SpecificTendererRequirement>
+				<cbc:TendererRequirementTypeCode listName="exclusion-ground">nati-ground</cbc:TendererRequirementTypeCode>
+			</cac:SpecificTendererRequirement>
+			<cac:SpecificTendererRequirement>
+				<cbc:TendererRequirementTypeCode listName="exclusion-ground">bankr-nat</cbc:TendererRequirementTypeCode>
+			</cac:SpecificTendererRequirement>
+			<cac:SpecificTendererRequirement>
+				<cbc:TendererRequirementTypeCode listName="exclusion-ground">corruption</cbc:TendererRequirementTypeCode>
+			</cac:SpecificTendererRequirement>
+			<cac:SpecificTendererRequirement>
+				<cbc:TendererRequirementTypeCode listName="exclusion-ground">crime-org</cbc:TendererRequirementTypeCode>
+			</cac:SpecificTendererRequirement>
+			<cac:SpecificTendererRequirement>
+				<cbc:TendererRequirementTypeCode listName="exclusion-ground">distorsion</cbc:TendererRequirementTypeCode>
+			</cac:SpecificTendererRequirement>
+			<cac:SpecificTendererRequirement>
+				<cbc:TendererRequirementTypeCode listName="exclusion-ground">envir-law</cbc:TendererRequirementTypeCode>
+			</cac:SpecificTendererRequirement>
+			<cac:SpecificTendererRequirement>
+				<cbc:TendererRequirementTypeCode listName="exclusion-ground">finan-laund</cbc:TendererRequirementTypeCode>
+			</cac:SpecificTendererRequirement>
+			<cac:SpecificTendererRequirement>
+				<cbc:TendererRequirementTypeCode listName="exclusion-ground">fraud</cbc:TendererRequirementTypeCode>
+			</cac:SpecificTendererRequirement>
+			<cac:SpecificTendererRequirement>
+				<cbc:TendererRequirementTypeCode listName="exclusion-ground">human-traffic</cbc:TendererRequirementTypeCode>
+			</cac:SpecificTendererRequirement>
+			<cac:SpecificTendererRequirement>
+				<cbc:TendererRequirementTypeCode listName="exclusion-ground">insolvency</cbc:TendererRequirementTypeCode>
+			</cac:SpecificTendererRequirement>
+			<cac:SpecificTendererRequirement>
+				<cbc:TendererRequirementTypeCode listName="exclusion-ground">labour-law</cbc:TendererRequirementTypeCode>
+			</cac:SpecificTendererRequirement>
+			<cac:SpecificTendererRequirement>
+				<cbc:TendererRequirementTypeCode listName="exclusion-ground">liq-admin</cbc:TendererRequirementTypeCode>
+			</cac:SpecificTendererRequirement>
+			<cac:SpecificTendererRequirement>
+				<cbc:TendererRequirementTypeCode listName="exclusion-ground">misrepresent</cbc:TendererRequirementTypeCode>
+			</cac:SpecificTendererRequirement>
+			<cac:SpecificTendererRequirement>
+				<cbc:TendererRequirementTypeCode listName="exclusion-ground">partic-confl</cbc:TendererRequirementTypeCode>
+			</cac:SpecificTendererRequirement>
+			<cac:SpecificTendererRequirement>
+				<cbc:TendererRequirementTypeCode listName="exclusion-ground">prep-confl</cbc:TendererRequirementTypeCode>
+			</cac:SpecificTendererRequirement>
+			<cac:SpecificTendererRequirement>
+				<cbc:TendererRequirementTypeCode listName="exclusion-ground">prof-misconduct</cbc:TendererRequirementTypeCode>
+			</cac:SpecificTendererRequirement>
+			<cac:SpecificTendererRequirement>
+				<cbc:TendererRequirementTypeCode listName="exclusion-ground">sanction</cbc:TendererRequirementTypeCode>
+			</cac:SpecificTendererRequirement>
+			<cac:SpecificTendererRequirement>
+				<cbc:TendererRequirementTypeCode listName="exclusion-ground">socsec-law</cbc:TendererRequirementTypeCode>
+			</cac:SpecificTendererRequirement>
+			<cac:SpecificTendererRequirement>
+				<cbc:TendererRequirementTypeCode listName="exclusion-ground">socsec-pay</cbc:TendererRequirementTypeCode>
+			</cac:SpecificTendererRequirement>
+			<cac:SpecificTendererRequirement>
+				<cbc:TendererRequirementTypeCode listName="exclusion-ground">susp-act</cbc:TendererRequirementTypeCode>
+			</cac:SpecificTendererRequirement>
+			<cac:SpecificTendererRequirement>
+				<cbc:TendererRequirementTypeCode listName="exclusion-ground">tax-pay</cbc:TendererRequirementTypeCode>
+			</cac:SpecificTendererRequirement>
+			<cac:SpecificTendererRequirement>
+				<cbc:TendererRequirementTypeCode listName="exclusion-ground">terr-offence</cbc:TendererRequirementTypeCode>
+			</cac:SpecificTendererRequirement>
+		</cac:TendererQualificationRequest>
+		<cac:TenderRecipientParty>
+			<cac:PartyIdentification>
+				<cbc:ID>ORG-0001</cbc:ID>
+			</cac:PartyIdentification>
+		</cac:TenderRecipientParty>
+		<cac:TenderValidityPeriod>
+			<cbc:DurationMeasure unitCode="DAY">30</cbc:DurationMeasure>
+		</cac:TenderValidityPeriod>
+		<cac:AppealTerms>
+			<cac:PresentationPeriod>
+				<cbc:Description languageID="DEU">Ein zulässiger Nachprüfungsantrag bei der genannten Vergabekammer kann allenfalls bis zur wirksamen Zuschlagserteilung erstellt werden. Eine wirksame Zuschlagserteilung ist erst möglich, wenn der Auftraggeber die unterlegenen Bieter über den Grund der vorgesehenen Nichtberücksichtigung ihres Angebots und den Namen des Bieters, dessen Angebot angenommen werden soll, in Textform informiert hat, und seit der Absendung der Information 15 Kalendertage (bei Versand per Telefax oder auf elektronischem Weg: 10 Kalendertage) vergangen sind. Ein Nachprüfungsantrag ist zulässig, soweit -der Bieter den gerügten Vergaberechtsverstoß schon im Vergabeverfahren erkannt und gegenüber dem Auftraggeber unverzüglich, also ohne schuldhaftes Zögern (in der Regel innerhalb weniger Tage und auch in schwierigen Fällen längstens innerhalb von 14 Tagen) gerügt hat, -Vergaberechtsverstöße, die aufgrund dieser Bekanntmachung erkennbar sind, nicht spätestens bis zum Ablauf des genannten Schlusstermins für den Eingang der Angebots oder Teilnahmeanträge genannten Frist gerügt werden, oder -Vergaberechtsverstöße, die erst in den Vergabeunterlagen erkennbar sind, nicht spätestens bis zum Ablauf des genannten Schlusstermins für den Eingang der Angebote oder Teilnahmeanträge genannten Frist gerügt werden. Teilt der Auftraggeber einem Bieter mit, dass er einer Rüge nicht abhelfen will, so kann der Bieter wegen dieser Rüge nur innerhalb von 15 Kalendertagen nach Eingang dieser Mitteilung einen Nachprüfungsantrag stellen.</cbc:Description>
+			</cac:PresentationPeriod>
+			<cac:AppealInformationParty>
+				<cac:PartyIdentification>
+					<cbc:ID schemeName="organization">ORG-0002</cbc:ID>
+				</cac:PartyIdentification>
+			</cac:AppealInformationParty>
+			<cac:AppealReceiverParty>
+				<cac:PartyIdentification>
+					<cbc:ID schemeName="organization">ORG-0002</cbc:ID>
+				</cac:PartyIdentification>
+			</cac:AppealReceiverParty>
+		</cac:AppealTerms>
+		<cac:Language>
+			<cbc:ID>DEU</cbc:ID>
+		</cac:Language>
+	</cac:TenderingTerms>
+	<cac:TenderingProcess>
+		<ext:UBLExtensions>
+			<ext:UBLExtension>
+				<ext:ExtensionContent>
+					<efext:EformsExtension>
+						<efbc:AccessToolName>Sämtliche Kommunikation im Rahmen des Vergabeverfahrens, hierzu gehört z.B. die Eingabe einer Bieterfrage und deren Beantwortung, erfolgt mithilfe elektronischer Mittel über diese Vergabeplattform. Die Einreichung von Bieterfragen wird ausschließlich über die vom Auftraggeber gewählte Vergabeplattform zugelassen.</efbc:AccessToolName>
+					</efext:EformsExtension>
+				</ext:ExtensionContent>
+			</ext:UBLExtension>
+		</ext:UBLExtensions>
+		<cbc:ProcedureCode listName="procurement-procedure-type">open</cbc:ProcedureCode>
+		<cbc:AccessToolsURI>https://www.vergabe.metropoleruhr.de/VMPSatellite/notice/CXPSYD4DZUG</cbc:AccessToolsURI>
+		<cac:ProcessJustification>
+			<cbc:ProcessReasonCode listName="accelerated-procedure">false</cbc:ProcessReasonCode>
+		</cac:ProcessJustification>
+		<cac:AuctionTerms>
+			<cbc:AuctionConstraintIndicator>false</cbc:AuctionConstraintIndicator>
+		</cac:AuctionTerms>
+	</cac:TenderingProcess>
+	<cac:ProcurementProject>
+		<cbc:ID schemeName="internalID">V001 25</cbc:ID>
+		<cbc:Name languageID="DEU">Zuschlagvertrag über die Lieferung von allen Produkten der Fa. Conen Holding GmbH</cbc:Name>
+		<cbc:Description languageID="DEU">Zuschlagsvertrag über die Lieferung von allen Produkten der Fa. Conen Holding GmbH</cbc:Description>
+		<cbc:ProcurementTypeCode listName="eforms-contract-nature">supplies</cbc:ProcurementTypeCode>
+		<cbc:Note languageID="DEU">Bekanntmachungs-ID: CXPSYD4DZUG
+
+
+Die Anforderung der Vergabeunterlagen, der Versand der Vergabeunterlagen und die Entgegennahme von Angeboten erfolgt ausschließlich über die Vergabeplattform www.vergabe.metropoleruhr.de oder www.vergabe.nrw.de. Der Auftraggeber führt das Vergabeverfahren über die Vergabeplattform Vergabemarktplatz Metropole Ruhr. Die Auftragsbekanntmachung sowie die Vergabeunterlagen stehen Bietern gem. § 9 Abs. 3 Satz 2 VgV auch ohne Registrierung auf dieser Vergabeplattform zur Verfügung. Das Einreichen eines Angebotes mithilfe elektronischer Mittel über diese Vergabeplattform wird zwingend verlangt. Eine Registrierung bei der Vergabeplattform Vergabemarktplatz Metropole Ruhr ist für die weitere aktive Teilnahme, insbesondere für die Abgabe eines Angebotes somit zwingend erforderlich (§ 9 Abs. 3 Satz 1 VgV). Sämtliche Kommunikation im Rahmen des Vergabeverfahrens, hierzu gehört z.B. die Eingabe einer Bieterfrage und deren Beantwortung, erfolgt mithilfe elektronischer Mittel über diese Vergabeplattform. Die Einreichung von Bieterfragen wird ausschließlich über die vom Auftraggeber gewählte Vergabeplattform zugelassen. Eine Beantwortung erfolgt ebenso ausschließlich über die vom Auftraggeber gewählte Vergabeplattform</cbc:Note>
+		<cbc:SMESuitableIndicator>false</cbc:SMESuitableIndicator>
+		<cac:RequestedTenderTotal>
+			<ext:UBLExtensions>
+				<ext:UBLExtension>
+					<ext:ExtensionContent>
+						<efext:EformsExtension>
+							<efbc:FrameworkMaximumAmount currencyID="EUR">775000.00</efbc:FrameworkMaximumAmount>
+						</efext:EformsExtension>
+					</ext:ExtensionContent>
+				</ext:UBLExtension>
+			</ext:UBLExtensions>
+		</cac:RequestedTenderTotal>
+		<cac:MainCommodityClassification>
+			<cbc:ItemClassificationCode listName="cpv">39100000</cbc:ItemClassificationCode>
+		</cac:MainCommodityClassification>
+		<cac:RealizedLocation>
+			<cbc:Description languageID="DEU">Eine Liste mit den Schuladressen ist den Vergabeunterlagen beigefügt</cbc:Description>
+			<cac:Address>
+				<cbc:StreetName>alle Schulen der Stadt Recklinghausen</cbc:StreetName>
+				<cbc:CityName>Recklinghausen</cbc:CityName>
+				<cbc:PostalZone>45657</cbc:PostalZone>
+				<cbc:CountrySubentityCode listName="nuts">DEA36</cbc:CountrySubentityCode>
+				<cac:Country>
+					<cbc:IdentificationCode>DEU</cbc:IdentificationCode>
+				</cac:Country>
+			</cac:Address>
+		</cac:RealizedLocation>
+		<cac:PlannedPeriod>
+			<cbc:StartDate>2025-04-01+02:00</cbc:StartDate>
+			<cbc:EndDate>2028-03-31+02:00</cbc:EndDate>
+		</cac:PlannedPeriod>
+		<cac:ContractExtension>
+			<cbc:MaximumNumberNumeric>1</cbc:MaximumNumberNumeric>
+			<cac:Renewal>
+				<cac:Period>
+					<cbc:Description languageID="DEU">Der Vertrag verlängert sich einmalig um ein weiteres Jahr, sofern er nicht mit einer Frist von 3 Monaten zum Ende der o.g. Laufzeit gekündigt wird</cbc:Description>
+				</cac:Period>
+			</cac:Renewal>
+		</cac:ContractExtension>
+	</cac:ProcurementProject>
+	<cac:ProcurementProjectLot>
+		<cbc:ID schemeName="Lot">LOT-0001</cbc:ID>
+		<cac:TenderingTerms>
+			<!-- <ext:UBLExtensions>
+				<ext:UBLExtension>
+					<ext:ExtensionContent>
+						<efext:EformsExtension>
+							<efac:SelectionCriteria>
+								<cbc:CriterionTypeCode listName="selection-criterion">other</cbc:CriterionTypeCode>
+								<cbc:Description languageID="DEU">Befähigung zur Berufsausübung einschließlich Auflagen hinsichtlich der Eintragung in einem Berufs- oder Handelsregister Auflistung und kurze Beschreibung der Bedingungen: Abgabe von Eigenerklärungen mit Hilfe des den Vergabeunterlagen beiliegenden Formblattes 124. Es werden Erklärungen bezüglich einer Eintragung in das Berufsregister, bezüglich der Zahlung von Steuern, Abgaben und Beiträgen zur gesetzlichen Sozialversicherung und der Mitgliedschaft in einer Berufsgenossenschaft verlangt. Sofern das sich bewerbende Unternehmen präqualifiziert ist, ist der Nachweis der Präqualifikation ausreichend.  Wirtschaftliche und finanzielle Leistungsfähigkeit Auflistung und kurze Beschreibung der Eignungskriterien: Abgabe von Eigenerklärungen mit Hilfe des den Vergabeunterlagen beiliegenden Formblattes 124. Es werden Erklärungen bezüglich des Umsatzes des Unternehmens in den letzten 3 abgeschlossenen Geschäftsjahren verlangt. Weiterhin müssen in den letzten 3 Geschäftsjahren vergleichbare Leistungen ausgeführt worden sein. Es muss erklärt werden, dass für die Ausführung der Leistungen die erforderlichen Arbeitskräfte zur Verfügung stehen. Es müssen Angaben bezüglich Insolvenzverfahren und Liquidiationen gemacht werden und es muss bestätigt werden, dass nachweislich keine schweren Verfehlungen begangen wurden, die die Zuverlässigkeit als Bewerber in Frage stellt. Sofern das sich bewerbende Unternehmen präqualifiziert ist, ist der Nachweis der Präqualifikation ausreichend.  Möglicherweise geforderte Mindeststandards: Ausführung von vergleichbaren Leistungen innerhalb der letzten 3 Geschäftsjahre.</cbc:Description>
+							</efac:SelectionCriteria>
+							<efac:StrategicProcurement>
+								<efbc:ApplicableLegalBasis listName="cvd-scope">false</efbc:ApplicableLegalBasis>
+							</efac:StrategicProcurement>
+						</efext:EformsExtension>
+					</ext:ExtensionContent>
+				</ext:UBLExtension>
+			</ext:UBLExtensions> -->
+			<cbc:VariantConstraintCode listName="permission">not-allowed</cbc:VariantConstraintCode>
+			<cbc:FundingProgramCode listName="eu-funded">no-eu-funds</cbc:FundingProgramCode>
+			<cbc:MultipleTendersCode listName="permission">not-allowed</cbc:MultipleTendersCode>
+			<cac:RequiredFinancialGuarantee>
+				<cbc:GuaranteeTypeCode listName="tender-guarantee-required">false</cbc:GuaranteeTypeCode>
+			</cac:RequiredFinancialGuarantee>
+			<cac:ProcurementLegislationDocumentReference>
+				<cbc:ID>vgv</cbc:ID>
+			</cac:ProcurementLegislationDocumentReference>
+			<cac:CallForTendersDocumentReference>
+				<ext:UBLExtensions>
+					<ext:UBLExtension>
+						<ext:ExtensionContent>
+							<efext:EformsExtension>
+								<efac:OfficialLanguages>
+									<cac:Language>
+										<cbc:ID>DEU</cbc:ID>
+									</cac:Language>
+								</efac:OfficialLanguages>
+							</efext:EformsExtension>
+						</ext:ExtensionContent>
+					</ext:UBLExtension>
+				</ext:UBLExtensions>
+				<cbc:ID>SomeTenderDocID1</cbc:ID>
+				<cbc:DocumentType>non-restricted-document</cbc:DocumentType>
+				<cac:Attachment>
+					<cac:ExternalReference>
+						<cbc:URI>https://www.vergabe.metropoleruhr.de/VMPSatellite/notice/CXPSYD4DZUG/documents</cbc:URI>
+					</cac:ExternalReference>
+				</cac:Attachment>
+			</cac:CallForTendersDocumentReference>
+			<cac:PaymentTerms>
+				<cbc:Note languageID="DEU">Abgabe von Eigenerklärungen mit Hilfe des den Vergabeunterlagen beiliegenden Formblattes 124. Es werden Erklärungen bezüglich des Umsatzes des Unternehmens in den letzten 3 abgeschlossenen Geschäftsjahren verlangt. Weiterhin müssen in den letzten 3 Geschäftsjahren vergleichbare Leistungen ausgeführt worden sein. Es muss erklärt werden, dass für die Ausführung der Leistungen die erforderlichen Arbeitskräfte zur Verfügung stehen. Es müssen Angaben bezüglich Insolvenzverfahren und Liquidiationen gemacht werden und es muss bestätigt werden, dass nachweislich keine schweren Verfehlungen begangen wurden, die die Zuverlässigkeit als Bewerber in Frage stellt. Sofern das sich bewerbende Unternehmen präqualifiziert ist, ist der Nachweis der Präqualifikation ausreichend.</cbc:Note>
+			</cac:PaymentTerms>
+			<cac:TendererQualificationRequest>
+				<cbc:CompanyLegalFormCode listName="required">true</cbc:CompanyLegalFormCode>
+				<cbc:CompanyLegalForm languageID="DEU">Gesamtschuldnerisch haftend mit einem bevollmächtigtem Vertreter.</cbc:CompanyLegalForm>
+			</cac:TendererQualificationRequest>
+			<cac:TendererQualificationRequest>
+				<cac:SpecificTendererRequirement>
+					<cbc:TendererRequirementTypeCode listName="missing-info-submission">late-all</cbc:TendererRequirementTypeCode>
+					<cbc:Description languageID="DEU">Fehlende Unterlagen werden gem. § 56 Abs. 2 und 4 VgV nachgefordert</cbc:Description>
+				</cac:SpecificTendererRequirement>
+			</cac:TendererQualificationRequest>
+			<cac:ContractExecutionRequirement>
+				<cbc:ExecutionRequirementCode listName="reserved-execution">no</cbc:ExecutionRequirementCode>
+			</cac:ContractExecutionRequirement>
+			<cac:ContractExecutionRequirement>
+				<cbc:ExecutionRequirementCode listName="ecatalog-submission">not-allowed</cbc:ExecutionRequirementCode>
+			</cac:ContractExecutionRequirement>
+			<cac:ContractExecutionRequirement>
+				<cbc:ExecutionRequirementCode listName="einvoicing">required</cbc:ExecutionRequirementCode>
+			</cac:ContractExecutionRequirement>
+			<cac:ContractExecutionRequirement>
+				<cbc:ExecutionRequirementCode listName="conditions">performance</cbc:ExecutionRequirementCode>
+				<cbc:Description languageID="DEU">Abgabe einer Eigenerklärung zur Umsetzung von Artikel 5k Absatz 3 der Verordnung (EU) 2022/576 des Rates vom 8. April 2022</cbc:Description>
+			</cac:ContractExecutionRequirement>
+			<cac:AwardingTerms>
+				<cac:AwardingCriterion>
+					<cac:SubordinateAwardingCriterion>
+						<ext:UBLExtensions>
+							<ext:UBLExtension>
+								<ext:ExtensionContent>
+									<efext:EformsExtension>
+										<efac:AwardCriterionParameter>
+											<efbc:ParameterCode listName="number-weight">per-exa</efbc:ParameterCode>
+											<efbc:ParameterNumeric>100.0</efbc:ParameterNumeric>
+										</efac:AwardCriterionParameter>
+									</efext:EformsExtension>
+								</ext:ExtensionContent>
+							</ext:UBLExtension>
+						</ext:UBLExtensions>
+						<cbc:AwardingCriterionTypeCode listName="award-criterion-type">price</cbc:AwardingCriterionTypeCode>
+						<cbc:Name languageID="DEU">Preis</cbc:Name>
+						<cbc:Description languageID="DEU">Preis</cbc:Description>
+					</cac:SubordinateAwardingCriterion>
+				</cac:AwardingCriterion>
+			</cac:AwardingTerms>
+			<cac:AdditionalInformationParty>
+				<cac:PartyIdentification>
+					<cbc:ID>ORG-0001</cbc:ID>
+				</cac:PartyIdentification>
+			</cac:AdditionalInformationParty>
+			<cac:TenderRecipientParty>
+				<cbc:EndpointID>https://www.vergabe.metropoleruhr.de/VMPSatellite/notice/CXPSYD4DZUG</cbc:EndpointID>
+				<cac:PartyIdentification>
+					<cbc:ID>ORG-0001</cbc:ID>
+				</cac:PartyIdentification>
+			</cac:TenderRecipientParty>
+			<cac:TenderValidityPeriod>
+				<cbc:DurationMeasure unitCode="DAY">30</cbc:DurationMeasure>
+			</cac:TenderValidityPeriod>
+			<cac:AppealTerms>
+				<cac:PresentationPeriod>
+					<cbc:Description languageID="DEU">Ein zulässiger Nachprüfungsantrag bei der genannten Vergabekammer kann allenfalls bis zur wirksamen Zuschlagserteilung erstellt werden. Eine wirksame Zuschlagserteilung ist erst möglich, wenn der Auftraggeber die unterlegenen Bieter über den Grund der vorgesehenen Nichtberücksichtigung ihres Angebots und den Namen des Bieters, dessen Angebot angenommen werden soll, in Textform informiert hat, und seit der Absendung der Information 15 Kalendertage (bei Versand per Telefax oder auf elektronischem Weg: 10 Kalendertage) vergangen sind. Ein Nachprüfungsantrag ist zulässig, soweit -der Bieter den gerügten Vergaberechtsverstoß schon im Vergabeverfahren erkannt und gegenüber dem Auftraggeber unverzüglich, also ohne schuldhaftes Zögern (in der Regel innerhalb weniger Tage und auch in schwierigen Fällen längstens innerhalb von 14 Tagen) gerügt hat, -Vergaberechtsverstöße, die aufgrund dieser Bekanntmachung erkennbar sind, nicht spätestens bis zum Ablauf des genannten Schlusstermins für den Eingang der Angebots oder Teilnahmeanträge genannten Frist gerügt werden, oder -Vergaberechtsverstöße, die erst in den Vergabeunterlagen erkennbar sind, nicht spätestens bis zum Ablauf des genannten Schlusstermins für den Eingang der Angebote oder Teilnahmeanträge genannten Frist gerügt werden. Teilt der Auftraggeber einem Bieter mit, dass er einer Rüge nicht abhelfen will, so kann der Bieter wegen dieser Rüge nur innerhalb von 15 Kalendertagen nach Eingang dieser Mitteilung einen Nachprüfungsantrag stellen.</cbc:Description>
+				</cac:PresentationPeriod>
+				<cac:AppealInformationParty>
+					<cac:PartyIdentification>
+						<cbc:ID schemeName="organization">ORG-0002</cbc:ID>
+					</cac:PartyIdentification>
+				</cac:AppealInformationParty>
+				<cac:AppealReceiverParty>
+					<cac:PartyIdentification>
+						<cbc:ID schemeName="organization">ORG-0002</cbc:ID>
+					</cac:PartyIdentification>
+				</cac:AppealReceiverParty>
+			</cac:AppealTerms>
+			<cac:Language>
+				<cbc:ID>DEU</cbc:ID>
+			</cac:Language>
+			<cac:PostAwardProcess>
+				<cbc:ElectronicOrderUsageIndicator>false</cbc:ElectronicOrderUsageIndicator>
+				<cbc:ElectronicPaymentUsageIndicator>false</cbc:ElectronicPaymentUsageIndicator>
+			</cac:PostAwardProcess>
+		</cac:TenderingTerms>
+		<cac:TenderingProcess>
+			<ext:UBLExtensions>
+				<ext:UBLExtension>
+					<ext:ExtensionContent>
+						<efext:EformsExtension>
+							<efbc:AccessToolName>Sämtliche Kommunikation im Rahmen des Vergabeverfahrens, hierzu gehört z.B. die Eingabe einer Bieterfrage und deren Beantwortung, erfolgt mithilfe elektronischer Mittel über diese Vergabeplattform. Die Einreichung von Bieterfragen wird ausschließlich über die vom Auftraggeber gewählte Vergabeplattform zugelassen.</efbc:AccessToolName>
+						</efext:EformsExtension>
+					</ext:ExtensionContent>
+				</ext:UBLExtension>
+			</ext:UBLExtensions>
+			<cbc:SubmissionMethodCode listName="esubmission">required</cbc:SubmissionMethodCode>
+			<cbc:GovernmentAgreementConstraintIndicator>true</cbc:GovernmentAgreementConstraintIndicator>
+			<cbc:AccessToolsURI>https://www.vergabe.metropoleruhr.de/VMPSatellite/notice/CXPSYD4DZUG</cbc:AccessToolsURI>
+			<cac:TenderSubmissionDeadlinePeriod>
+				<cbc:EndDate>2025-03-28+01:00</cbc:EndDate>
+				<cbc:EndTime>10:00:00+01:00</cbc:EndTime>
+			</cac:TenderSubmissionDeadlinePeriod>
+			<cac:AdditionalInformationRequestPeriod>
+				<cbc:EndDate>2025-03-17+01:00</cbc:EndDate>
+				<cbc:EndTime>23:59:59+01:00</cbc:EndTime>
+			</cac:AdditionalInformationRequestPeriod>
+			<cac:OpenTenderEvent>
+				<cbc:OccurrenceDate>2025-03-28+01:00</cbc:OccurrenceDate>
+				<cbc:OccurrenceTime>10:00:00+01:00</cbc:OccurrenceTime>
+				<cbc:Description languageID="DEU">Bieter oder Bevollmächtigte sind nicht zugelassen</cbc:Description>
+				<cac:OccurenceLocation>
+					<cbc:Description languageID="DEU">Stadt Recklinghausen Zimmer 3.09 Rathausplatz 3 45657 Recklinghausen</cbc:Description>
+				</cac:OccurenceLocation>
+			</cac:OpenTenderEvent>
+			<cac:AuctionTerms>
+				<cbc:AuctionConstraintIndicator>false</cbc:AuctionConstraintIndicator>
+			</cac:AuctionTerms>
+			<cac:FrameworkAgreement>
+				<cbc:MaximumOperatorQuantity>1</cbc:MaximumOperatorQuantity>
+			</cac:FrameworkAgreement>
+			<cac:ContractingSystem>
+				<cbc:ContractingSystemTypeCode listName="framework-agreement">fa-wo-rc</cbc:ContractingSystemTypeCode>
+			</cac:ContractingSystem>
+			<cac:ContractingSystem>
+				<cbc:ContractingSystemTypeCode listName="dps-usage">none</cbc:ContractingSystemTypeCode>
+			</cac:ContractingSystem>
+		</cac:TenderingProcess>
+		<cac:ProcurementProject>
+			<cbc:ID schemeName="internalID">V001 25</cbc:ID>
+			<cbc:Name languageID="DEU">Zuschlagvertrag über die Lieferung von allen Produkten der Fa. Conen Holding GmbH</cbc:Name>
+			<cbc:Description languageID="DEU">Zuschlagsvertrag über die Lieferung von allen Produkten der Fa. Conen Holding GmbH</cbc:Description>
+			<cbc:ProcurementTypeCode listName="contract-nature">supplies</cbc:ProcurementTypeCode>
+			<cbc:SMESuitableIndicator>false</cbc:SMESuitableIndicator>
+			<cac:ProcurementAdditionalType>
+				<cbc:ProcurementTypeCode listName="strategic-procurement">none</cbc:ProcurementTypeCode>
+			</cac:ProcurementAdditionalType>
+			<cac:MainCommodityClassification>
+				<cbc:ItemClassificationCode listName="cpv">39100000</cbc:ItemClassificationCode>
+			</cac:MainCommodityClassification>
+			<cac:RealizedLocation>
+				<cbc:Description languageID="DEU">Eine Liste mit den Schuladressen ist den Vergabeunterlagen beigefügt</cbc:Description>
+				<cac:Address>
+					<cbc:StreetName>alle Schulen der Stadt Recklinghausen</cbc:StreetName>
+					<cbc:CityName>Recklinghausen</cbc:CityName>
+					<cbc:PostalZone>45657</cbc:PostalZone>
+					<cbc:CountrySubentityCode listName="nuts">DEA36</cbc:CountrySubentityCode>
+					<cac:Country>
+						<cbc:IdentificationCode>DEU</cbc:IdentificationCode>
+					</cac:Country>
+				</cac:Address>
+			</cac:RealizedLocation>
+			<cac:PlannedPeriod>
+				<cbc:StartDate>2025-04-01+02:00</cbc:StartDate>
+				<cbc:EndDate>2028-03-31+02:00</cbc:EndDate>
+			</cac:PlannedPeriod>
+			<cac:ContractExtension>
+				<cbc:MaximumNumberNumeric>1</cbc:MaximumNumberNumeric>
+				<cac:Renewal>
+					<cac:Period>
+						<cbc:Description languageID="DEU">Der Vertrag verlängert sich einmalig um ein weiteres Jahr, sofern er nicht mit einer Frist von 3 Monaten zum Ende der o.g. Laufzeit gekündigt wird</cbc:Description>
+					</cac:Period>
+				</cac:Renewal>
+			</cac:ContractExtension>
+		</cac:ProcurementProject>
+	</cac:ProcurementProjectLot>
+</ContractNotice>


### PR DESCRIPTION
closes #19 

## Description

This PR handles the creation of suggested patches from a list of suggested criteria.
The suggested patches are parsed from the given suggested criteria and from the existing domain knowledge files.
The `GppPatchSuggester` does most of the work to get the patches ready for the applier.
